### PR TITLE
[FEAT] 공통응답 및 헬스체크 구현

### DIFF
--- a/src/main/java/com/seatlock/seatlock/common/ApiResponse.java
+++ b/src/main/java/com/seatlock/seatlock/common/ApiResponse.java
@@ -1,0 +1,56 @@
+package com.seatlock.seatlock.common;
+
+import com.seatlock.seatlock.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final T data;
+    private final ErrorResponse error;
+    private final LocalDateTime timestamp;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null, LocalDateTime.now());
+    }
+
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(true, null, null, LocalDateTime.now());
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(
+                false,
+                null,
+                new ErrorResponse(errorCode.getCode(), errorCode.getMessage()),
+                LocalDateTime.now()
+        );
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(
+                false,
+                null,
+                new ErrorResponse(errorCode.getCode(), message),
+                LocalDateTime.now()
+        );
+    }
+
+
+
+
+
+
+
+    @Getter
+    @AllArgsConstructor
+    public static class ErrorResponse {
+        private final String code;
+        private final String message;
+    }
+}

--- a/src/main/java/com/seatlock/seatlock/common/exception/CustomException.java
+++ b/src/main/java/com/seatlock/seatlock/common/exception/CustomException.java
@@ -1,0 +1,21 @@
+package com.seatlock.seatlock.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+
+}

--- a/src/main/java/com/seatlock/seatlock/common/exception/ErrorCode.java
+++ b/src/main/java/com/seatlock/seatlock/common/exception/ErrorCode.java
@@ -1,0 +1,31 @@
+package com.seatlock.seatlock.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    INTERNAL_SERVER_ERROR("C001", "서버 내부 오류가 발생했습니다."),
+    INVALID_REQUEST("C002", "잘못된 요청입니다."),
+
+    // User (U)
+    USER_NOT_FOUND("U001", "존재하지 않는 사용자입니다."),
+
+    // Seat (S)
+    SEAT_NOT_FOUND("S001", "존재하지 않는 좌석입니다."),
+    SEAT_ALREADY_RESERVED("S002", "이미 예약된 좌석입니다."),
+
+    // Reservation (R)
+    RESERVATION_NOT_FOUND("R001", "존재하지 않는 예약입니다."),
+    ALREADY_RESERVED("R002", "이미 예약 내역이 존재합니다."),
+    LOCK_ACQUISITION_FAILED("R003", "락 획득에 실패했습니다. 잠시 후 다시 시도해주세요."),
+
+    // Database (D)
+    DATABASE_CONNECTION_ERROR("D001", "데이터베이스 연결에 실패했습니다.");
+
+
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/seatlock/seatlock/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/seatlock/seatlock/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.seatlock.seatlock.common.exception;
+
+
+import com.seatlock.seatlock.common.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+        log.error("CustomException: code={}, message={}", e.getErrorCode().getCode(), e.getMessage());
+
+        ApiResponse<Void> response = ApiResponse.error(e.getErrorCode());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Unexpected Exception: ", e);
+
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(response);
+    }
+
+
+}

--- a/src/main/java/com/seatlock/seatlock/health/HealthCheckController.java
+++ b/src/main/java/com/seatlock/seatlock/health/HealthCheckController.java
@@ -1,0 +1,23 @@
+package com.seatlock.seatlock.health;
+
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1")
+public class HealthCheckController {
+
+    @GetMapping("/health")
+    public ResponseEntity<HealthCheckResponseDTO> healthCheck() {
+        HealthCheckResponseDTO response = HealthCheckResponseDTO.of("UP", "seat-lock");
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/seatlock/seatlock/health/HealthCheckController.java
+++ b/src/main/java/com/seatlock/seatlock/health/HealthCheckController.java
@@ -7,10 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
-
 @RestController
 @RequestMapping("/api/v1")
 public class HealthCheckController {

--- a/src/main/java/com/seatlock/seatlock/health/HealthCheckController.java
+++ b/src/main/java/com/seatlock/seatlock/health/HealthCheckController.java
@@ -1,6 +1,7 @@
 package com.seatlock.seatlock.health;
 
 
+import com.seatlock.seatlock.common.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,8 +16,9 @@ import java.util.Map;
 public class HealthCheckController {
 
     @GetMapping("/health")
-    public ResponseEntity<HealthCheckResponseDTO> healthCheck() {
-        HealthCheckResponseDTO response = HealthCheckResponseDTO.of("UP", "seat-lock");
+    public ResponseEntity<ApiResponse<HealthCheckResponseDTO>> healthCheck() {
+        HealthCheckResponseDTO data = HealthCheckResponseDTO.of("UP", "seat-lock");
+        ApiResponse<HealthCheckResponseDTO> response = ApiResponse.success(data);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/seatlock/seatlock/health/HealthCheckResponseDTO.java
+++ b/src/main/java/com/seatlock/seatlock/health/HealthCheckResponseDTO.java
@@ -1,0 +1,10 @@
+package com.seatlock.seatlock.health;
+
+public record HealthCheckResponseDTO(
+        String status,
+        String service
+) {
+    public static HealthCheckResponseDTO of(String status, String service) {
+        return new HealthCheckResponseDTO(status, service);
+    }
+}


### PR DESCRIPTION
## 🔍 작업 내용 (What)
- 헬스체크 API 구현 (`GET /api/v1/health`)
- 공통 응답 포맷 구현 (`ApiResponse<T>`)
- 전역 예외 처리 구현 (`GlobalExceptionHandler`)
- 커스텀 에러 코드 관리 (`ErrorCode` enum)

## 🛠️ 기술적 변경 및 설계 (How & Why)

### 1. 헬스체크 API
- **경로**: `GET /api/v1/health`
- **응답**: 서버 상태(`UP`), 서비스명(`seat-lock`)
- **목적**: 서버 가동 여부 확인, 부하 테스트 전 서버 상태 점검

### 2. 공통 응답 포맷 (ApiResponse<T>)
- **구조**: 
  - `success`: 성공/실패 여부 (boolean)
  - `data`: 실제 데이터 (제네릭 타입 T)
  - `error`: 에러 정보 (ErrorResponse - code, message)
  - `timestamp`: 응답 시각 (LocalDateTime)
  
- **설계 의도**:
  - 제네릭 사용으로 **타입 안정성** 확보
  - 정적 팩토리 메서드(`success()`, `error()`)로 **생성 로직 단순화**
  - 모든 API 응답을 **일관된 형식**으로 통일

### 3. 에러 코드 관리 (ErrorCode)
- **구조**: Enum으로 에러 코드와 메시지 중앙 관리
- **분류**: 
  - Common(C): 공통 에러
  - User(U): 사용자 도메인
  - Seat(S): 좌석 도메인
  - Reservation(R): 예약 도메인
  - Database(D): DB 연결 에러
  
- **설계 의도**: 
  - 에러 코드 중복 방지
  - 도메인별 접두사로 **에러 추적 용이**
  - 향후 동시성 문제 관련 에러 추가 예정 (예: `LOCK_ACQUISITION_FAILED`)

### 4. 전역 예외 처리 (GlobalExceptionHandler)
- **역할**: `@RestControllerAdvice`로 모든 컨트롤러의 예외를 일괄 처리
- **처리 방식**:
  - `CustomException`: 비즈니스 로직 예외 → HTTP 400
  - `Exception`: 예상치 못한 예외 → HTTP 500
  
- **설계 의도**:
  - 일관된 에러 응답 형식 보장


### 5. CustomException
- **구조**: `RuntimeException` 상속 + `ErrorCode` 포함


## 📂 패키지 구조
```
src/main/java/com/seatlock/seatlock/
├── common/
│   ├── ApiResponse.java
│   └── exception/
│       ├── CustomException.java
│       ├── ErrorCode.java
│       └── GlobalExceptionHandler.java
└── health/
    ├── HealthCheckController.java
    └── HealthCheckResponseDTO.java
```

## 📝 API 응답 예시

### 성공 응답
```json
{
  "success": true,
  "data": {
    "status": "UP",
    "service": "seat-lock"
  },
  "error": null,
  "timestamp": "2025-12-22T12:34:56.789"
}
```

### 에러 응답
```json
{
  "success": false,
  "data": null,
  "error": {
    "code": "S001",
    "message": "존재하지 않는 좌석입니다."
  },
  "timestamp": "2025-12-22T12:34:56.789"
}
```



## ✅ 체크리스트
- [x] 로컬 환경에서 테스트를 통과했는가?
- [x] 빌드가 잘 되는가?
- [x] 포스트맨 성공했는가? (`GET /api/v1/health` 200 OK 확인)

## 🔗 관련 이슈
Closes #1 