### PR TITLE
[FEAT] 도메인 Entity 및 Repository, DataInitializer 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ out/
 /.nb-gradle/
 
 .env
+application-local.yml
 
 ### VS Code ###
 .vscode/

--- a/src/main/java/com/seatlock/seatlock/common/BaseEntity.java
+++ b/src/main/java/com/seatlock/seatlock/common/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.seatlock.seatlock.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/seatlock/seatlock/common/BaseEntity.java
+++ b/src/main/java/com/seatlock/seatlock/common/BaseEntity.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
-@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
     @CreationTimestamp

--- a/src/main/java/com/seatlock/seatlock/common/config/DataInitializer.java
+++ b/src/main/java/com/seatlock/seatlock/common/config/DataInitializer.java
@@ -1,0 +1,4 @@
+package com.seatlock.seatlock.common.config;
+
+public class DataInitializer {
+}

--- a/src/main/java/com/seatlock/seatlock/common/config/DataInitializer.java
+++ b/src/main/java/com/seatlock/seatlock/common/config/DataInitializer.java
@@ -9,6 +9,7 @@ import com.seatlock.seatlock.domain.seat.SeatRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +19,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DataInitializer {
+public class DataInitializer implements CommandLineRunner {
 
     private final MemberRepository memberRepository;
     private final EventRepository eventRepository;
@@ -28,9 +29,9 @@ public class DataInitializer {
     private static final int TOTAL_SEATS = 1_000;
     private static final int BATCH_SIZE = 1_000;
 
-    @PostConstruct//Bean 생성 후 아래의 메서드가 실행됨
+    @Override
     @Transactional
-    public void init() {
+    public void run(String... args) throws Exception {
         log.info("==================================================");
         log.info("더미 데이터 생성 시작");
         log.info("==================================================");

--- a/src/main/java/com/seatlock/seatlock/common/config/DataInitializer.java
+++ b/src/main/java/com/seatlock/seatlock/common/config/DataInitializer.java
@@ -1,4 +1,141 @@
 package com.seatlock.seatlock.common.config;
 
+import com.seatlock.seatlock.domain.event.Event;
+import com.seatlock.seatlock.domain.event.EventRepository;
+import com.seatlock.seatlock.domain.member.entity.Member;
+import com.seatlock.seatlock.domain.member.repository.MemberRepository;
+import com.seatlock.seatlock.domain.seat.Seat;
+import com.seatlock.seatlock.domain.seat.SeatRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
 public class DataInitializer {
+
+    private final MemberRepository memberRepository;
+    private final EventRepository eventRepository;
+    private final SeatRepository seatRepository;
+
+    private static final int TOTAL_MEMBERS = 100_000;
+    private static final int TOTAL_SEATS = 1_000;
+    private static final int BATCH_SIZE = 1_000;
+
+    @PostConstruct//Bean 생성 후 아래의 메서드가 실행됨
+    @Transactional
+    public void init() {
+        log.info("==================================================");
+        log.info("더미 데이터 생성 시작");
+        log.info("==================================================");
+
+        // 기존 데이터 확인
+        long memberCount = memberRepository.count();
+        long eventCount = eventRepository.count();
+        long seatCount = seatRepository.count();
+
+        if (memberCount > 0 || eventCount > 0 || seatCount > 0) {
+            log.info("이미 데이터가 존재합니다. 더미 데이터 생성을 건너뜁니다.");
+            log.info("Member: {}, Event: {}, Seat: {}", memberCount, eventCount, seatCount);
+            return;
+        }
+
+        long startTime = System.currentTimeMillis();
+
+        // 1. Member 생성
+        createMembers();
+
+        // 2. Event 생성
+        Event event = createEvent();
+
+        // 3. Seat 생성
+        createSeats(event);
+
+        long endTime = System.currentTimeMillis();
+        long duration = (endTime - startTime) / 1000;
+
+        log.info("==================================================");
+        log.info("더미 데이터 생성 완료 (소요 시간: {}초)", duration);
+        log.info("✅ Member: {}명", memberRepository.count());
+        log.info("✅ Event: {}개", eventRepository.count());
+        log.info("✅ Seat: {}개", seatRepository.count());
+        log.info("==================================================");
+
+    }
+
+    private void createMembers() {
+        log.info("Member {}명 생성 중...", TOTAL_MEMBERS);
+        long startTime = System.currentTimeMillis();
+
+        int batches = TOTAL_MEMBERS / BATCH_SIZE;
+        for (int i = 0; i < batches; i++) {
+            List<Member> memberBatch = new ArrayList<>();
+            for (int j = 0; j < BATCH_SIZE; j++) {
+                int memberNumber = i * BATCH_SIZE + j + 1;
+                Member member = Member.of("user_" + memberNumber);
+                memberBatch.add(member);
+            }
+            memberRepository.saveAll(memberBatch);
+            memberRepository.flush();
+
+            if ((i + 1) % 10 == 0) {
+                log.info("Member 생성 진행 중... {}/{} 배치 완료", i + 1, batches);
+            }
+        }
+
+        long endTime = System.currentTimeMillis();
+        log.info("✅ Member {}명 생성 완료 ({}초)", TOTAL_MEMBERS, (endTime - startTime) / 1000);
+    }
+
+    private Event createEvent() {
+        log.info("Event 생성 중...");
+        Event event = Event.of("2025 프리미엄 스포츠 경기", TOTAL_SEATS);
+        eventRepository.save(event);
+        log.info("✅ Event 생성 완료: {}", event.getEventName());
+        return event;
+    }
+
+    private void createSeats(Event event) {
+        log.info("Seat {}개 생성 중...", TOTAL_SEATS);
+        long startTime = System.currentTimeMillis();
+
+        List<Seat> allSeats = new ArrayList<>();
+
+        // A등급: 250석 (A-001 ~ A-250)
+        allSeats.addAll(createSeatsByGrade(event, "A", 250));
+
+        // B등급: 250석 (B-001 ~ B-250)
+        allSeats.addAll(createSeatsByGrade(event, "B", 250));
+
+        // C등급: 250석 (C-001 ~ C-250)
+        allSeats.addAll(createSeatsByGrade(event, "C", 250));
+
+        // D등급: 250석 (D-001 ~ D-250)
+        allSeats.addAll(createSeatsByGrade(event, "D", 250));
+
+        // Batch Insert
+        seatRepository.saveAll(allSeats);
+        seatRepository.flush();
+
+        long endTime = System.currentTimeMillis();
+        log.info("✅ Seat {}개 생성 완료 ({}초)", TOTAL_SEATS, (endTime - startTime) / 1000);
+    }
+
+
+    private List<Seat> createSeatsByGrade(Event event, String grade, int count) {
+        List<Seat> seats = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            String seatNumber = String.format("%s-%03d", grade, i);
+            Seat seat = Seat.of(event, seatNumber);
+            seats.add(seat);
+        }
+        return seats;
+    }
+
 }

--- a/src/main/java/com/seatlock/seatlock/domain/event/Event.java
+++ b/src/main/java/com/seatlock/seatlock/domain/event/Event.java
@@ -1,0 +1,49 @@
+package com.seatlock.seatlock.domain.event;
+
+
+import com.seatlock.seatlock.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Auditable;
+
+@Entity
+@Table(name = "events")
+@Getter
+@NoArgsConstructor
+public class Event extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "event_name", nullable = false, length = 200)
+    private String eventName;
+
+    @Column(name = "total_seats", nullable = false)
+    private Integer totalSeats;
+
+    @Column(name = "available_seats", nullable = false)
+    private Integer availableSeats;
+
+    @Builder
+    public Event(String eventName, Integer totalSeats, Integer availableSeats) {
+        this.eventName = eventName;
+        this.totalSeats = totalSeats;
+        this.availableSeats = availableSeats;
+    }
+
+    public static Event of(String eventName, Integer totalSeats) {
+        return Event.builder()
+                .eventName(eventName)
+                .totalSeats(totalSeats)
+                .availableSeats(totalSeats) // 초기값은 전체 좌석 수와 동일
+                .build();
+    }
+}

--- a/src/main/java/com/seatlock/seatlock/domain/event/Event.java
+++ b/src/main/java/com/seatlock/seatlock/domain/event/Event.java
@@ -8,10 +8,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Auditable;
 
 @Entity
 @Table(name = "events")
@@ -31,6 +31,10 @@ public class Event extends BaseEntity {
 
     @Column(name = "available_seats", nullable = false)
     private Integer availableSeats;
+
+    @Version
+    @Column(name = "version")
+    private Integer version;
 
     @Builder
     public Event(String eventName, Integer totalSeats, Integer availableSeats) {

--- a/src/main/java/com/seatlock/seatlock/domain/event/EventRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/event/EventRepository.java
@@ -1,0 +1,6 @@
+package com.seatlock.seatlock.domain.event;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/src/main/java/com/seatlock/seatlock/domain/health/HealthCheckController.java
+++ b/src/main/java/com/seatlock/seatlock/domain/health/HealthCheckController.java
@@ -1,4 +1,4 @@
-package com.seatlock.seatlock.health;
+package com.seatlock.seatlock.domain.health;
 
 
 import com.seatlock.seatlock.common.ApiResponse;

--- a/src/main/java/com/seatlock/seatlock/domain/health/HealthCheckResponseDTO.java
+++ b/src/main/java/com/seatlock/seatlock/domain/health/HealthCheckResponseDTO.java
@@ -1,4 +1,4 @@
-package com.seatlock.seatlock.health;
+package com.seatlock.seatlock.domain.health;
 
 public record HealthCheckResponseDTO(
         String status,

--- a/src/main/java/com/seatlock/seatlock/domain/member/entity/Member.java
+++ b/src/main/java/com/seatlock/seatlock/domain/member/entity/Member.java
@@ -1,0 +1,39 @@
+package com.seatlock.seatlock.domain.member.entity;
+
+
+import com.seatlock.seatlock.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Table(name = "members")
+@Getter
+@NoArgsConstructor
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "username", nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Builder
+    public Member(String username) {
+        this.username = username;
+    }
+
+    public static Member of(String username) {
+        return Member.builder().username(username).build();
+    }
+
+
+}

--- a/src/main/java/com/seatlock/seatlock/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.seatlock.seatlock.domain.member.repository;
+
+import com.seatlock.seatlock.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUsername(String username);
+
+    boolean existsByUsername(String username);
+}

--- a/src/main/java/com/seatlock/seatlock/domain/seat/Seat.java
+++ b/src/main/java/com/seatlock/seatlock/domain/seat/Seat.java
@@ -51,7 +51,7 @@ public class Seat extends BaseEntity {
     private SeatStatus status;
 
     @Version
-    @Column(name = "version")
+    @Column(name = "version", nullable = false)
     private Integer version;
 
     @Builder
@@ -59,10 +59,9 @@ public class Seat extends BaseEntity {
         this.event = event;
         this.seatNumber = seatNumber;
         this.status = status != null ? status : SeatStatus.AVAILABLE;
-        this.version = 0;
     }
 
-    public static Seat  of(Event event, String seatNumber) {
+    public static Seat of(Event event, String seatNumber) {
         return Seat.builder()
                 .event(event)
                 .seatNumber(seatNumber)

--- a/src/main/java/com/seatlock/seatlock/domain/seat/Seat.java
+++ b/src/main/java/com/seatlock/seatlock/domain/seat/Seat.java
@@ -1,0 +1,73 @@
+package com.seatlock.seatlock.domain.seat;
+
+import com.seatlock.seatlock.common.BaseEntity;
+import com.seatlock.seatlock.domain.event.Event;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Table(
+        name = "seats",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_event_seat_number",
+                        columnNames = {"event_id", "seat_number"}
+                )
+        }
+)
+@Getter
+@NoArgsConstructor
+public class Seat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(name = "seat_number", nullable = false, length = 10)
+    private String seatNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private SeatStatus status;
+
+    @Version
+    @Column(name = "version")
+    private Integer version;
+
+    @Builder
+    public Seat(Event event, String seatNumber, SeatStatus status) {
+        this.event = event;
+        this.seatNumber = seatNumber;
+        this.status = status != null ? status : SeatStatus.AVAILABLE;
+        this.version = 0;
+    }
+
+    public static Seat  of(Event event, String seatNumber) {
+        return Seat.builder()
+                .event(event)
+                .seatNumber(seatNumber)
+                .status(SeatStatus.AVAILABLE)
+                .build();
+    }
+
+}

--- a/src/main/java/com/seatlock/seatlock/domain/seat/SeatRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/seat/SeatRepository.java
@@ -1,4 +1,6 @@
 package com.seatlock.seatlock.domain.seat;
 
-public interface SeatRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
 }

--- a/src/main/java/com/seatlock/seatlock/domain/seat/SeatRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/seat/SeatRepository.java
@@ -1,0 +1,4 @@
+package com.seatlock.seatlock.domain.seat;
+
+public interface SeatRepository {
+}

--- a/src/main/java/com/seatlock/seatlock/domain/seat/SeatStatus.java
+++ b/src/main/java/com/seatlock/seatlock/domain/seat/SeatStatus.java
@@ -1,0 +1,13 @@
+package com.seatlock.seatlock.domain.seat;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatStatus {
+    AVAILABLE("예약 가능"),
+    RESERVED("예약됨");
+
+    private final String description;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,12 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
+        jdbc:
+          batch_size: 1000           # Batch Insert 크기
+        order_inserts: true          # INSERT 쿼리 정렬
+        order_updates: true          # UPDATE 쿼리 정렬
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG                          # SQL 쿼리 로그
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE  # 파라미터 바인딩 로그


### PR DESCRIPTION
## 🔍 작업 내용 (What)
- 핵심 도메인 Entity 및 Repository 구현 (Member, Event, Seat)
- BaseEntity 추상 클래스로 공통 필드 관리 (createdAt, updatedAt)
- 더미 데이터 자동 생성기 구현 (DataInitializer)
- 100,000명 Member + 1,000개 Seat 자동 생성
- Batch Insert 설정으로 대용량 데이터 생성 최적화

## 🛠️ 기술적 변경 및 설계 (How & Why)

### 1. BaseEntity 추상 클래스
**위치**: `common/BaseEntity.java`

**설계**:
```java
@MappedSuperclass
public abstract class BaseEntity {
    @CreationTimestamp
    private LocalDateTime createdAt;
    
    @UpdateTimestamp
    private LocalDateTime updatedAt;
}
```

**이유**:
- 모든 Entity에 중복되는 시간 필드 제거
- 유지보수성: BaseEntity 하나만 수정하면 전체 도메인에 반영
- 일관성: 모든 테이블이 동일한 시간 필드 보유

---

### 2. Member 도메인
**위치**: `domain/member/`

**Entity 설계**:
```java
@Entity
@Table(name = "members")
public class Member extends BaseEntity {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;
    
    @Column(unique = true, nullable = false)
    private String username;
}
```

**핵심 포인트**:
- 테이블명 `members`: MySQL 예약어 `users` 회피
- username만 사용: 인증/인가 범위 밖이므로 최소화

---

### 3. Event 도메인
**위치**: `domain/event/`

**Entity 설계**:
```java
@Entity
public class Event extends BaseEntity {
    private String eventName;
    private Integer totalSeats;      // 1,000 (고정)
    private Integer availableSeats;  // 동적 관리
}
```

**이유**:
- `availableSeats`: 매번 Seat 테이블 COUNT 하지 않고 빠른 조회

---

### 4. Seat 도메인
**위치**: `domain/seat/`

**Entity 설계**:
```java
@Entity
@Table(uniqueConstraints = {
    @UniqueConstraint(columnNames = {"event_id", "seat_number"})
})
public class Seat extends BaseEntity {
    @ManyToOne(fetch = FetchType.LAZY)
    private Event event;
    
    private String seatNumber;  // A-001, B-001 등
    
    @Enumerated(EnumType.STRING)
    private SeatStatus status;  // AVAILABLE, RESERVED
    
    @Version
    private Integer version;    // 낙관적 락
}
```

**핵심 포인트**:
- **@Version**: 낙관적 락으로 동시성 제어
- **UNIQUE 제약**: (event_id, seat_number) 중복 방지
- **SeatStatus**: AVAILABLE/RESERVED 2단계만

**SeatStatus 단순화 이유**:
- 예약 취소 제거: 프로젝트 범위 밖
- 동시성 테스트에 AVAILABLE → RESERVED 전이만 필요

---

### 5. DataInitializer (더미 데이터 생성기)
**위치**: `common/config/DataInitializer.java`

**구조**:
```java
@Component
public class DataInitializer {
    @PostConstruct
    @Transactional
    public void init() {
        createMembers();   // 100,000명
        createEvent();     // 1개
        createSeats();     // 1,000개
    }
}
```

**Batch Insert 최적화**:
```java
for (int i = 0; i < 100; i++) {
    List<Member> batch = new ArrayList<>(1000);
    // ... 1000개 추가
    memberRepository.saveAll(batch);
    memberRepository.flush();  // 영속성 컨텍스트 비우기
}
```

**application.yml 설정**:
```yaml
hibernate:
  jdbc:
    batch_size: 1000       # 1000개씩 묶어서 INSERT
  order_inserts: true      # 같은 테이블끼리 정렬
  order_updates: true      # UPDATE도 정렬
```


**좌석 생성 규칙**:
- A등급: A-001 ~ A-250 (250석)
- B등급: B-001 ~ B-250 (250석)
- C등급: C-001 ~ C-250 (250석)
- D등급: D-001 ~ D-250 (250석)

**중복 생성 방지**:
```java
if (memberRepository.count() > 0) {
    log.info("이미 데이터가 존재합니다.");
    return;
}
```



---

## 🎯 동시성 영향도
- [x] **동시성 제어 준비 완료**
  - `Seat.version`: 낙관적 락 필드 포함
  - `Event.availableSeats`: 동시 업데이트 발생 지점

---





## ✅ 체크리스트
- [x] 로컬 환경에서 테스트를 통과했는가?
  - 서버 시작 시 더미 데이터 자동 생성 확인
  - DB에서 데이터 검증 완료
- [x] 빌드가 잘 되는가?
  - Gradle 빌드 성공
- [x] 포스트맨 성공했는가?
  - 헬스체크 API 정상 동작 (`GET /api/v1/health`)
- [x] Builder 패턴 또는 정적 팩토리 메서드 사용
- [x] 외래키 관계 명확히 설정 (@ManyToOne, @JoinColumn)
- [x] UNIQUE 제약조건 어노테이션으로 명시
- [x] Batch Insert 설정 적용 (application.yml)
- [x] application-local.yml 생성 및 .gitignore 추가

---

## 🔗 관련 이슈
Closes #3 