### PR TITLE
[FEAT] 락 없는 취약 상태의 예약 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/seatlock/seatlock/domain/event/entity/Event.java
+++ b/src/main/java/com/seatlock/seatlock/domain/event/entity/Event.java
@@ -1,4 +1,4 @@
-package com.seatlock.seatlock.domain.event;
+package com.seatlock.seatlock.domain.event.entity;
 
 
 import com.seatlock.seatlock.global.BaseEntity;
@@ -49,5 +49,12 @@ public class Event extends BaseEntity {
                 .totalSeats(totalSeats)
                 .availableSeats(totalSeats) // 초기값은 전체 좌석 수와 동일
                 .build();
+    }
+
+    public void decreaseAvailableSeats() {
+        if (this.availableSeats <= 0) {
+            throw new IllegalStateException("예약 가능한 좌석이 없습니다.");
+        }
+        this.availableSeats--;
     }
 }

--- a/src/main/java/com/seatlock/seatlock/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/event/repository/EventRepository.java
@@ -1,6 +1,6 @@
 package com.seatlock.seatlock.domain.event.repository;
 
-import com.seatlock.seatlock.domain.event.Event;
+import com.seatlock.seatlock.domain.event.entity.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventRepository extends JpaRepository<Event, Long> {

--- a/src/main/java/com/seatlock/seatlock/domain/health/HealthCheckController.java
+++ b/src/main/java/com/seatlock/seatlock/domain/health/HealthCheckController.java
@@ -4,6 +4,7 @@ package com.seatlock.seatlock.domain.health;
 import com.seatlock.seatlock.global.ApiResponse;
 import com.seatlock.seatlock.domain.health.service.HealthCheckService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/controller/ReservationController.java
@@ -1,0 +1,40 @@
+package com.seatlock.seatlock.domain.reservation.controller;
+
+import com.seatlock.seatlock.global.ApiResponse;
+import com.seatlock.seatlock.domain.reservation.dto.ReservationRequestDTO;
+import com.seatlock.seatlock.domain.reservation.dto.ReservationResponseDTO;
+import com.seatlock.seatlock.domain.reservation.service.ReservationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/reservations")
+@RequiredArgsConstructor
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ReservationResponseDTO>> createReservation(
+            @Valid @RequestBody ReservationRequestDTO request
+    ) {
+        log.info("예약 요청 - memberId: {}, seatId: {}", request.memberId(), request.seatId());
+
+        ReservationResponseDTO response = reservationService.createReservation(
+                request.memberId(),
+                request.seatId()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/dto/ReservationRequestDTO.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/dto/ReservationRequestDTO.java
@@ -1,0 +1,12 @@
+package com.seatlock.seatlock.domain.reservation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ReservationRequestDTO(
+        @NotNull(message = "회원 ID는 필수입니다.")
+        Long memberId,
+
+        @NotNull(message = "좌석 ID는 필수입니다")
+        Long seatId
+) {
+}

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/dto/ReservationRequestDTO.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/dto/ReservationRequestDTO.java
@@ -6,7 +6,7 @@ public record ReservationRequestDTO(
         @NotNull(message = "회원 ID는 필수입니다.")
         Long memberId,
 
-        @NotNull(message = "좌석 ID는 필수입니다")
+        @NotNull(message = "좌석 ID는 필수입니다.")
         Long seatId
 ) {
 }

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/dto/ReservationResponseDTO.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/dto/ReservationResponseDTO.java
@@ -1,0 +1,24 @@
+package com.seatlock.seatlock.domain.reservation.dto;
+
+import com.seatlock.seatlock.domain.reservation.entity.Reservation;
+
+import java.time.LocalDateTime;
+
+public record ReservationResponseDTO(
+        Long reservationId,
+        Long memberId,
+        Long seatId,
+        Long eventId,
+        LocalDateTime reservedAt
+) {
+    // 정적 팩토리 메서드
+    public static ReservationResponseDTO from(Reservation reservation) {
+        return new ReservationResponseDTO(
+                reservation.getId(),
+                reservation.getMemberId(),
+                reservation.getSeatId(),
+                reservation.getEventId(),
+                reservation.getCreatedAt()  // BaseEntity의 createdAt
+        );
+    }
+}

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/entity/Reservation.java
@@ -1,0 +1,53 @@
+package com.seatlock.seatlock.domain.reservation.entity;
+
+import com.seatlock.seatlock.global.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "reservations", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "event_id"}),
+        @UniqueConstraint(columnNames = {"seat_id"})
+})
+@Getter
+@NoArgsConstructor
+public class Reservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "seat_id", nullable = false)
+    private Long seatId;
+
+    @Column(name = "event_id", nullable = false)
+    private Long eventId;
+
+
+    @Builder
+    public Reservation(Long memberId, Long seatId, Long eventId) {
+        this.memberId = memberId;
+        this.seatId = seatId;
+        this.eventId = eventId;
+    }
+
+    // 정적 팩토리 메서드
+    public static Reservation of(Long memberId, Long seatId, Long eventId) {
+        return Reservation.builder()
+                .memberId(memberId)
+                .seatId(seatId)
+                .eventId(eventId)
+                .build();
+    }
+}

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/repository/ReservationRepository.java
@@ -4,4 +4,6 @@ import com.seatlock.seatlock.domain.reservation.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    boolean existsByMemberIdAndEventId(Long seatNumber, Long eventId);
 }

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/repository/ReservationRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-    boolean existsByMemberIdAndEventId(Long seatNumber, Long eventId);
+    boolean existsByMemberIdAndEventId(Long memberId, Long eventId);
 }

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,7 @@
+package com.seatlock.seatlock.domain.reservation.repository;
+
+import com.seatlock.seatlock.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/service/ReservationService.java
@@ -1,0 +1,58 @@
+package com.seatlock.seatlock.domain.reservation.service;
+
+import com.seatlock.seatlock.global.exception.CustomException;
+import com.seatlock.seatlock.global.exception.ErrorCode;
+import com.seatlock.seatlock.domain.event.entity.Event;
+import com.seatlock.seatlock.domain.reservation.dto.ReservationResponseDTO;
+import com.seatlock.seatlock.domain.reservation.entity.Reservation;
+import com.seatlock.seatlock.domain.reservation.repository.ReservationRepository;
+import com.seatlock.seatlock.domain.seat.entity.Seat;
+import com.seatlock.seatlock.domain.seat.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final SeatRepository seatRepository;
+
+    @Transactional
+    public ReservationResponseDTO createReservation(Long memberId, Long seatId) {
+        log.info("예약 시작 - memberId: {}, seatId: {}", memberId, seatId);
+
+        // 1. 좌석 조회
+        Seat seat = seatRepository.findById(seatId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+
+        // 2. 좌석 예약 가능 여부 확인
+        if (!seat.isAvailable()) {
+            throw new CustomException(ErrorCode.SEAT_ALREADY_RESERVED);
+        }
+
+        // 3. 중복 예약 체크 (같은 이벤트에 이미 예약했는지)
+        Long eventId = seat.getEvent().getId();
+        if (reservationRepository.existsByMemberIdAndEventId(memberId, eventId)) {
+            throw new CustomException(ErrorCode.ALREADY_RESERVED_THIS_EVENT);
+        }
+
+        // 4. 좌석 예약 처리 (AVAILABLE → RESERVED)
+        seat.reserve();
+
+        // 5. Event의 availableSeats 감소
+        Event event = seat.getEvent();
+        event.decreaseAvailableSeats();
+
+        // 6. 예약 생성
+        Reservation reservation = Reservation.of(memberId, seatId, eventId);
+        reservationRepository.save(reservation);
+
+        log.info("예약 완료 - reservationId: {}", reservation.getId());
+
+        return ReservationResponseDTO.from(reservation);
+    }
+}

--- a/src/main/java/com/seatlock/seatlock/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/seatlock/seatlock/domain/reservation/service/ReservationService.java
@@ -34,8 +34,9 @@ public class ReservationService {
             throw new CustomException(ErrorCode.SEAT_ALREADY_RESERVED);
         }
 
+        Event event = seat.getEvent();
         // 3. 중복 예약 체크 (같은 이벤트에 이미 예약했는지)
-        Long eventId = seat.getEvent().getId();
+        Long eventId = event.getId();
         if (reservationRepository.existsByMemberIdAndEventId(memberId, eventId)) {
             throw new CustomException(ErrorCode.ALREADY_RESERVED_THIS_EVENT);
         }
@@ -44,7 +45,6 @@ public class ReservationService {
         seat.reserve();
 
         // 5. Event의 availableSeats 감소
-        Event event = seat.getEvent();
         event.decreaseAvailableSeats();
 
         // 6. 예약 생성

--- a/src/main/java/com/seatlock/seatlock/domain/seat/entity/Seat.java
+++ b/src/main/java/com/seatlock/seatlock/domain/seat/entity/Seat.java
@@ -1,7 +1,8 @@
-package com.seatlock.seatlock.domain.seat;
+package com.seatlock.seatlock.domain.seat.entity;
 
+import com.seatlock.seatlock.domain.seat.SeatStatus;
 import com.seatlock.seatlock.global.BaseEntity;
-import com.seatlock.seatlock.domain.event.Event;
+import com.seatlock.seatlock.domain.event.entity.Event;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -67,6 +68,17 @@ public class Seat extends BaseEntity {
                 .seatNumber(seatNumber)
                 .status(SeatStatus.AVAILABLE)
                 .build();
+    }
+
+    public boolean isAvailable() {
+        return status == SeatStatus.AVAILABLE;
+    }
+
+    public void reserve() {
+        if (this.status != SeatStatus.AVAILABLE) {
+            throw new IllegalStateException("예약 가능한 상태가 아닙니다.");
+        }
+        this.status = SeatStatus.RESERVED;
     }
 
 }

--- a/src/main/java/com/seatlock/seatlock/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/seatlock/seatlock/domain/seat/repository/SeatRepository.java
@@ -1,6 +1,6 @@
 package com.seatlock.seatlock.domain.seat.repository;
 
-import com.seatlock.seatlock.domain.seat.Seat;
+import com.seatlock.seatlock.domain.seat.entity.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {

--- a/src/main/java/com/seatlock/seatlock/global/config/DataInitializer.java
+++ b/src/main/java/com/seatlock/seatlock/global/config/DataInitializer.java
@@ -1,10 +1,10 @@
 package com.seatlock.seatlock.global.config;
 
-import com.seatlock.seatlock.domain.event.Event;
+import com.seatlock.seatlock.domain.event.entity.Event;
 import com.seatlock.seatlock.domain.event.repository.EventRepository;
 import com.seatlock.seatlock.domain.member.entity.Member;
 import com.seatlock.seatlock.domain.member.repository.MemberRepository;
-import com.seatlock.seatlock.domain.seat.Seat;
+import com.seatlock.seatlock.domain.seat.entity.Seat;
 import com.seatlock.seatlock.domain.seat.repository.SeatRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/seatlock/seatlock/global/exception/ErrorCode.java
+++ b/src/main/java/com/seatlock/seatlock/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR("C001", "서버 내부 오류가 발생했습니다."),
     INVALID_REQUEST("C002", "잘못된 요청입니다."),
+    INVALID_INPUT("C002", "입력값이 올바르지 않습니다."),
 
     // User (U)
     USER_NOT_FOUND("U001", "존재하지 않는 사용자입니다."),

--- a/src/main/java/com/seatlock/seatlock/global/exception/ErrorCode.java
+++ b/src/main/java/com/seatlock/seatlock/global/exception/ErrorCode.java
@@ -9,7 +9,7 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR("C001", "서버 내부 오류가 발생했습니다."),
     INVALID_REQUEST("C002", "잘못된 요청입니다."),
-    INVALID_INPUT("C002", "입력값이 올바르지 않습니다."),
+    INVALID_INPUT("C003", "입력값이 올바르지 않습니다."),
 
     // User (U)
     USER_NOT_FOUND("U001", "존재하지 않는 사용자입니다."),

--- a/src/main/java/com/seatlock/seatlock/global/exception/ErrorCode.java
+++ b/src/main/java/com/seatlock/seatlock/global/exception/ErrorCode.java
@@ -20,10 +20,7 @@ public enum ErrorCode {
 
     // Reservation (R)
     RESERVATION_NOT_FOUND("R001", "존재하지 않는 예약입니다."),
-    ALREADY_RESERVED("R002", "이미 예약 내역이 존재합니다."),
-    LOCK_ACQUISITION_FAILED("R003", "락 획득에 실패했습니다. 잠시 후 다시 시도해주세요."),
-
-    // Reservation 도메인 (R로 시작)
+    LOCK_ACQUISITION_FAILED("R002", "락 획득에 실패했습니다. 잠시 후 다시 시도해주세요."),
     ALREADY_RESERVED_THIS_EVENT("R003", "이미 이 이벤트의 좌석을 예약하셨습니다."),
     NO_AVAILABLE_SEATS("R004", "예약 가능한 좌석이 없습니다."),
 

--- a/src/main/java/com/seatlock/seatlock/global/exception/ErrorCode.java
+++ b/src/main/java/com/seatlock/seatlock/global/exception/ErrorCode.java
@@ -22,8 +22,14 @@ public enum ErrorCode {
     ALREADY_RESERVED("R002", "이미 예약 내역이 존재합니다."),
     LOCK_ACQUISITION_FAILED("R003", "락 획득에 실패했습니다. 잠시 후 다시 시도해주세요."),
 
+    // Reservation 도메인 (R로 시작)
+    ALREADY_RESERVED_THIS_EVENT("R003", "이미 이 이벤트의 좌석을 예약하셨습니다."),
+    NO_AVAILABLE_SEATS("R004", "예약 가능한 좌석이 없습니다."),
+
     // Database (D)
     DATABASE_CONNECTION_ERROR("D001", "데이터베이스 연결에 실패했습니다.");
+
+
 
 
     private final String code;

--- a/src/main/java/com/seatlock/seatlock/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/seatlock/seatlock/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.seatlock.seatlock.global.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -17,6 +18,29 @@ public class GlobalExceptionHandler {
         log.error("CustomException: code={}, message={}", e.getErrorCode().getCode(), e.getMessage());
 
         ApiResponse<Void> response = ApiResponse.error(e.getErrorCode());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        // 첫 번째 에러 메시지 추출
+        String errorMessage = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .orElse("입력값이 올바르지 않습니다.");
+
+        log.error("Validation Exception: {}", errorMessage);
+
+        // INVALID_INPUT 에러 코드 사용
+        ApiResponse<Void> response = ApiResponse.error(
+                ErrorCode.INVALID_INPUT,
+                errorMessage
+        );
+
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(response);


### PR DESCRIPTION
## 🔍 작업 내용 (What)
- As-Is 예약 API 구현 (락 없는 취약 상태)
- Reservation 도메인 전체 구현
- 의도적으로 동시성 제어 없이 구현하여 문제 재현 준비

## 🛠️ 기술적 변경 및 설계 (How & Why)

### 1. Reservation Entity
**위치**: `domain/reservation/entity/Reservation.java`

**필드 구성**:
```java
@Entity
@Table(uniqueConstraints = {
    @UniqueConstraint(columnNames = {"member_id", "event_id"}),  // 1인 1매
    @UniqueConstraint(columnNames = {"seat_id"})                 // 좌석 중복 방지
})
public class Reservation extends BaseEntity {
    private Long id;
    private Long memberId;
    private Long seatId;
    private Long eventId;
    // BaseEntity의 createdAt을 예약 시각으로 활용
}
```

**핵심 설계 결정**:
- **UNIQUE 제약조건**: DB 레벨 최후 방어선
  - `(member_id, event_id)`: 1인 1매 제한
  - `(seat_id)`: 좌석 중복 예약 방지

**UNIQUE 제약의 역할과 한계**:
- ✅ 막아주는 것: 최종 데이터 정합성 (DB 레벨 중복 방지)
- ❌ 못 막는 것:
  - 동시 트랜잭션의 Race Condition
  - 불필요한 롤백 대량 발생 
  - Event.availableSeats의 Lost Update
  - 사용자에게 에러 노출

---

### 2. Reservation Repository
**위치**: `domain/reservation/repository/ReservationRepository.java`
```java
public interface ReservationRepository extends JpaRepository<Reservation, Long> {
    boolean existsByMemberIdAndEventId(Long memberId, Long eventId);
}
```

**메서드 설명**:
- `existsByMemberIdAndEventId`: 1인 1매 제한 체크

---

### 3. Reservation DTO (Record)
**위치**: `domain/reservation/dto/`

#### ReservationRequestDTO
```java
public record ReservationRequestDTO(
    @NotNull(message = "회원 ID는 필수입니다.")
    Long memberId,
    
    @NotNull(message = "좌석 ID는 필수입니다.")
    Long seatId
) {}
```

#### ReservationResponseDTO
```java
public record ReservationResponseDTO(
    Long reservationId,
    Long memberId,
    Long seatId,
    Long eventId,
    LocalDateTime reservedAt
) {
    public static ReservationResponseDTO from(Reservation reservation) {
        return new ReservationResponseDTO(
            reservation.getId(),
            reservation.getMemberId(),
            reservation.getSeatId(),
            reservation.getEventId(),
            reservation.getCreatedAt()  // BaseEntity 활용
        );
    }
}
```

**Record 선택 이유**:
- 불변 객체 (자동 final)
- Getter 자동 생성 (필드명())
- equals/hashCode/toString 자동
- 코드량 감소

---

### 4. ReservationService (의도적 취약점)
**위치**: `domain/reservation/service/ReservationService.java`
```java
@Transactional
public ReservationResponseDTO createReservation(Long memberId, Long seatId) {
    // 1. 좌석 조회
    Seat seat = seatRepository.findById(seatId)
        .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
    
    // 2. 좌석 예약 가능 여부 확인
    if (!seat.isAvailable()) {
        throw new CustomException(ErrorCode.SEAT_ALREADY_RESERVED);
    }
    
    // 3. 중복 예약 체크
    if (reservationRepository.existsByMemberIdAndEventId(memberId, eventId)) {
        throw new CustomException(ErrorCode.ALREADY_RESERVED_THIS_EVENT);
    }
    
    // 4. 좌석 예약 처리
    seat.reserve();  // AVAILABLE → RESERVED
    
    // 5. Event availableSeats 감소
    event.decreaseAvailableSeats();
    
    // 6. 예약 생성
    Reservation reservation = Reservation.of(memberId, seatId, eventId);
    return ReservationResponseDTO.from(reservationRepository.save(reservation));
}
```

**의도적 취약점 (Race Condition 발생 구간)**:
```java
Time   Thread 1                          Thread 2
────────────────────────────────────────────────────
t1     findById(seatId=500)
       → AVAILABLE ✅
       
t2                                       findById(seatId=500)
                                         → AVAILABLE ✅ (동시 조회!)
       
t3     isAvailable() → true
t4                                       isAvailable() → true
t5     seat.reserve()
t6                                       seat.reserve()
t7     event.decreaseAvailableSeats()
t8                                       event.decreaseAvailableSeats()
t9     save(reservation) → 성공
t10                                      save(reservation) → UNIQUE 위반!
```

**문제점**:
1. **조회 시점과 예약 시점 사이 시간 차이**: 둘 다 "예약 가능"이라고 판단
2. **Event.availableSeats Lost Update**: 2번 감소해야 하는데 1번만 감소 (동시 읽기)
3. **대량 Exception 발생**: 1,000석에 100,000명 요청 → 99,000개 롤백

**왜 락을 안 썼나?**
- **의도적**: As-Is 단계는 문제 재현이 목표
- JMeter 부하 테스트로 동시성 문제 가시화
- To-Be 단계에서 Redis 분산 락으로 해결

---

### 5. Entity 비즈니스 로직 개선

#### Seat Entity
```java
public boolean isAvailable() {
    return this.status == SeatStatus.AVAILABLE;
}

public void reserve() {
    if (this.status != SeatStatus.AVAILABLE) {
        throw new IllegalStateException("예약 가능한 상태가 아닙니다.");
    }
    this.status = SeatStatus.RESERVED;
}
```

**개선 포인트**:
- 상태 전이 검증 추가 
- 동시성 문제 디버깅 시 명확한 에러 메시지

#### Event Entity
```java
public void decreaseAvailableSeats() {
    if (this.availableSeats <= 0) {
        throw new IllegalStateException("예약 가능한 좌석이 없습니다.");
    }
    this.availableSeats--;
}
```

**개선 포인트**:
- 음수 방지 (비즈니스 규칙 위반)
- 데이터 정합성 보호

---

### 6. ReservationController
**위치**: `domain/reservation/controller/ReservationController.java`
```java
@PostMapping
public ResponseEntity<ApiResponse<ReservationResponseDTO>> createReservation(
    @Valid @RequestBody ReservationRequestDTO request
) {
    ReservationResponseDTO response = reservationService.createReservation(
        request.memberId(),
        request.seatId()
    );
    
    return ResponseEntity
        .status(HttpStatus.CREATED)
        .body(ApiResponse.success(response));
}
```

**핵심 포인트**:
- `@Valid`: DTO 검증 (memberId, seatId null 체크)
- `HttpStatus.CREATED`: 201 상태 코드 (리소스 생성)
- `ApiResponse`: 공통 응답 포맷 적용

---

### 7. GlobalExceptionHandler - Validation 예외 추가
**위치**: `global/exception/GlobalExceptionHandler.java`
```java
@ExceptionHandler(MethodArgumentNotValidException.class)
public ResponseEntity<ApiResponse<Void>> handleValidationException(
    MethodArgumentNotValidException e
) {
    String errorMessage = e.getBindingResult()
        .getFieldErrors()
        .stream()
        .findFirst()
        .map(fieldError -> fieldError.getDefaultMessage())
        .orElse("입력값이 올바르지 않습니다.");
    
    ApiResponse<Void> response = ApiResponse.error("C002", errorMessage);
    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
}
```

**추가 이유**:
- `@Valid` 검증 실패 시 `MethodArgumentNotValidException` 발생
- 이전에는 Exception 핸들러로 잡혀서 "서버 내부 오류" 반환 (부적절)
- 이제는 "회원 ID는 필수입니다." 등 명확한 메시지 반환

---

### 8. ErrorCode 추가
```java
// Common
INVALID_INPUT("C002", "입력값이 올바르지 않습니다."),

// Reservation
RESERVATION_NOT_FOUND("R001", "존재하지 않는 예약입니다."),
LOCK_ACQUISITION_FAILED("R002", "락 획득에 실패했습니다. 잠시 후 다시 시도해주세요."),
ALREADY_RESERVED_THIS_EVENT("R003", "이미 이 이벤트의 좌석을 예약하셨습니다."),
NO_AVAILABLE_SEATS("R004", "예약 가능한 좌석이 없습니다."),
```



## 🧪 테스트 결과

### 1. 정상 예약 (201)
```json
POST /api/v1/reservations
{
  "memberId": 1,
  "seatId": 1
}

Response:
{
  "success": true,
  "data": {
    "reservationId": 1,
    "memberId": 1,
    "seatId": 1,
    "eventId": 1,
    "reservedAt": "2025-12-23T20:50:00"
  }
}
```

### 2. Validation 에러 (400)
```json
{
  "memberId": null,
  "seatId": 1
}

Response:
{
  "success": false,
  "error": {
    "code": "C002",
    "message": "회원 ID는 필수입니다."
  }
}
```

### 3. 중복 예약 (400)
```json
{
  "memberId": 1,
  "seatId": 2
}

Response:
{
  "success": false,
  "error": {
    "code": "R003",
    "message": "이미 이 이벤트의 좌석을 예약하셨습니다."
  }
}
```

### 4. 이미 예약된 좌석 (400)
```json
{
  "memberId": 2,
  "seatId": 1
}

Response:
{
  "success": false,
  "error": {
    "code": "R002",
    "message": "이미 예약된 좌석입니다."
  }
}
```


**확인 사항**:
- ✅ requestId로 요청 추적 가능
- ✅ txId로 트랜잭션 범위 명확
- ✅ Repository 실행 시간 측정
- ✅ Service 전체 실행 시간 측정

---

## 🔧 개발 가이드 준수 사항
- [x] Entity에 비즈니스 로직 메서드 구현
- [x] 정적 팩토리 메서드 사용 (Reservation.of())
- [x] DTO는 Record로 구현
- [x] 클래스명 컨벤션: ~DTO, ~Controller, ~Service
- [x] Constructor Injection (@RequiredArgsConstructor)
- [x] @Transactional 적용
- [x] GlobalExceptionHandler 활용
- [x] ApiResponse 공통 포맷

---

## 🎯 동시성 영향도
- [x] **의도적 취약 상태 완성**
  - 락 없이 @Transactional만 사용
  - Race Condition 발생 가능 구간 존재
  - UNIQUE 제약은 최후 방어선 (Exception 발생)
- [x] **다음 단계 준비 완료**
  - JMeter 부하 테스트로 문제 재현 가능
  - 로그로 동시성 문제 추적 가능

---


## ✅ 체크리스트
- [x] 로컬 환경에서 테스트를 통과했는가?
  - 정상 예약: 201 Created
  - Validation 에러: 400 Bad Request
  - 중복 예약 에러: 400 Bad Request
  - 이미 예약된 좌석 에러: 400 Bad Request
- [x] 빌드가 잘 되는가?
- [x] 포스트맨 성공했는가?
- [x] DB 확인
  - reservations 테이블에 데이터 적재
  - seats 상태 AVAILABLE → RESERVED
  - events availableSeats 감소
- [x] 로그 확인
  - requestId, txId 포함
  - [Service], [Repository] 태그
  - 실행 시간 측정
---

## 🔗 관련 이슈
Closes #7 
```

---
